### PR TITLE
V4 docsfix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
       - master
     types:
       - closed
-  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This grants the github action bot write permissions in order to push to the docs-ci repo. It also removes the `workflow_dispatch` parameter since it won't work anyway due to other security constraints in the project configuration.