### PR TITLE
Establish PHP 8.3+ modernization baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         php-version: ['8.3', '8.4', '8.5']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: shivammathur/setup-php@v2
         with:
@@ -21,7 +21,7 @@ jobs:
           extensions: sodium
           coverage: none
 
-      - uses: ramsey/composer-install@v3
+      - uses: ramsey/composer-install@v4
 
       - name: Validate composer files
         run: composer validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,33 @@
-name: PHPUnit Testing
+name: CI
 
 on:
   push:
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-version: ['8.3', '8.4', '8.5']
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-    - name: Set up PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        coverage: none
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: sodium
+          coverage: none
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate
+      - uses: ramsey/composer-install@v3
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Validate composer files
+        run: composer validate
 
-    - name: Run tests
-      run: ./vendor/bin/phpunit
+      - name: Lint PHP files
+        run: composer lint
+
+      - name: Run PHPUnit
+        run: composer test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checkout master branch
       - name: Checkout master branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: master
 
@@ -49,14 +49,14 @@ jobs:
 
       # Configure GitHub Pages
       - name: Configure Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v6
 
       # Upload the generated docs static files as an artifact
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       # Deploy the artifact to GitHub Pages
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,384 @@
+# AGENTS.md
+
+## Project intent
+
+Cryptex is a small PHP library for authenticated symmetric encryption using PHP's Sodium extension.
+
+The goal of this repository is not novelty, cleverness, or framework-style abstraction. The goal is boring correctness: a small, modern, secure, maintainable PHP encryption API whose behavior is explicit, tested, documented, and unsurprising.
+
+Prefer simple, auditable code over clever code.
+
+## Working principles
+
+- Keep the library small.
+- Keep the public API minimal and intentional.
+- Make security-relevant behavior explicit.
+- Preserve backward compatibility unless a major-version change is clearly justified.
+- Prefer standard PHP, Composer, PHPUnit, and Sodium primitives.
+- Avoid dependencies unless they clearly improve correctness, safety, or maintainability.
+- Avoid speculative abstractions, service containers, interfaces, traits, magic methods, reflection, global state, or framework coupling.
+- Every change should make the package easier to trust.
+
+## Current package shape
+
+- Language: PHP.
+- Package manager: Composer.
+- Namespace: `cryptex\`.
+- Main source file: `src/Cryptex.php`.
+- Tests: `tests/`.
+- The package should remain usable as a lightweight Composer dependency.
+
+Do not restructure the repository into an application. This is a library.
+
+## Security model
+
+Cryptex should provide authenticated encryption for caller-supplied plaintext using libsodium.
+
+Expected properties:
+
+- Confidentiality: ciphertext should not reveal plaintext without the correct secret.
+- Integrity: tampering with ciphertext, nonce, tag, version, or envelope data must cause decryption failure.
+- Misuse resistance where reasonable: unsafe states should be rejected early.
+- Clear failure behavior: decryption must never return unauthenticated plaintext.
+- Explicit format handling: ciphertext formats must be versioned or clearly recognized.
+
+Out of scope:
+
+- Protecting against compromised hosts.
+- Protecting secrets after the PHP process or server is compromised.
+- Inventing custom cryptographic primitives.
+- Password policy enforcement.
+- Key storage or secret management.
+
+## Cryptography rules
+
+Use Sodium primitives directly.
+
+Allowed primitives:
+
+- Authenticated encryption: `sodium_crypto_aead_xchacha20poly1305_ietf_*`.
+- Password/key derivation when deriving from passphrases: `sodium_crypto_pwhash()` with Argon2id.
+- Randomness: `random_bytes()`.
+- Constant-time comparisons where comparisons are needed: `hash_equals()` or Sodium equivalents.
+- Encoding: Sodium encoding helpers where appropriate.
+
+Do not:
+
+- Implement custom encryption, MAC, padding, KDF, nonce generation, or random generation.
+- Use OpenSSL as a replacement unless there is a deliberate documented migration reason.
+- Use unauthenticated encryption modes.
+- Silently truncate keys, salts, nonces, or ciphertexts.
+- Accept malformed ciphertext.
+- Return partially decrypted data.
+- Log secrets, plaintext, derived keys, salts, nonces, or raw binary payloads.
+
+## API design
+
+The public API should be small, explicit, and stable.
+
+Prefer these public methods:
+
+- `Cryptex::encrypt(...)`
+- `Cryptex::decrypt(...)`
+- `Cryptex::generateSalt(...)`
+
+Only add public methods when they solve a real compatibility or safety problem.
+
+When changing ciphertext formats:
+
+- New encryption output should use a versioned format.
+- Decryption may support legacy formats when necessary.
+- Legacy behavior must be tested.
+- Format detection must be deterministic and fail closed.
+- Unknown versions must throw a clear exception.
+
+If legacy v4 hex ciphertext remains supported, either:
+
+- keep `decrypt()` able to read it safely, or
+- provide an explicit `decryptLegacyHex()` method.
+
+Do not make ambiguous APIs where the same parameter means different things without documentation.
+
+## Backward compatibility
+
+Before changing behavior, identify whether the change affects:
+
+- ciphertext format,
+- salt handling,
+- key derivation,
+- exception types,
+- PHP version requirements,
+- Composer package requirements,
+- public method signatures.
+
+Breaking changes require:
+
+- clear documentation,
+- changelog entry,
+- migration notes,
+- tests for old and new behavior,
+- a major version bump.
+
+Prefer compatibility paths when they do not compromise security or clarity.
+
+## Implementation standards
+
+Use modern PHP style.
+
+Required:
+
+- `declare(strict_types=1);`
+- explicit parameter and return types,
+- strict comparisons where applicable,
+- binary-safe string handling,
+- clear exception classes,
+- no dead code,
+- no redundant catch-and-rethrow blocks,
+- no uninitialized variables in cleanup paths,
+- no cleanup that destroys values returned to the caller.
+
+Use `substr()` for binary slicing. Do not introduce an `mbstring` dependency for binary operations.
+
+Composer requirements must declare required PHP extensions, including at minimum:
+
+- `ext-sodium`
+
+Only declare `ext-mbstring` if the code truly requires it, which it should not for core encryption.
+
+## Memory handling
+
+Be careful with `sodium_memzero()`.
+
+Do:
+
+- wipe derived keys and other temporary secret buffers when practical.
+- guard cleanup so it only runs on initialized strings.
+- avoid wiping values that must be returned to the caller.
+
+Do not:
+
+- call `sodium_memzero()` on uninitialized variables.
+- wipe `$plaintext` immediately before returning it.
+- wipe caller-owned inputs in a way that creates surprising PHP behavior.
+- let cleanup errors mask the original cryptographic error.
+
+Memory wiping in PHP has limitations. Use it carefully and modestly, not performatively.
+
+## Error handling
+
+Failure modes should be explicit.
+
+Use project-specific exceptions where useful:
+
+- `EncryptionException`
+- `DecryptionException`
+- `SaltLengthException`
+- `NonceLengthException`
+- `EncodingException` if encoding/decoding failures are meaningfully distinct.
+
+Catch `\Throwable` only when wrapping lower-level failures with clearer library exceptions.
+
+Do not use unqualified `Exception` inside the `cryptex` namespace unless intentionally referring to `cryptex\Exception`.
+
+Decryption failures should not reveal unnecessary detail. It is acceptable to distinguish malformed input from authentication failure in tests and internal code, but public errors should remain safe and clear.
+
+## Ciphertext format guidance
+
+Prefer a self-contained, versioned ciphertext envelope for new formats.
+
+A reasonable modern format is:
+
+version || salt || nonce || ciphertext_and_tag
+
+Then encode with a transport-safe encoding such as base64url without padding.
+
+Document:
+
+- version byte,
+- salt length,
+- nonce length,
+- tag length,
+- minimum decoded length,
+- encoding variant,
+- legacy format behavior.
+
+Validate decoded length before slicing.
+
+Minimum length for an XChaCha20-Poly1305 envelope must account for:
+
+- version byte,
+- salt,
+- nonce,
+- authentication tag.
+
+Malformed payloads must fail closed.
+
+## Testing requirements
+
+Tests are not optional. Changes are incomplete without tests.
+
+At minimum, cover:
+
+- successful encrypt/decrypt round trip,
+- different ciphertext for repeated encryption of the same plaintext,
+- wrong key fails,
+- wrong salt fails where applicable,
+- tampered ciphertext fails,
+- tampered nonce fails,
+- tampered tag fails,
+- malformed encoding fails,
+- too-short payload fails,
+- unsupported version fails,
+- empty plaintext succeeds,
+- binary plaintext succeeds,
+- large plaintext succeeds,
+- non-ASCII plaintext succeeds,
+- legacy ciphertext compatibility if supported,
+- generated salt length,
+- invalid salt length,
+- exception types for expected failure modes.
+
+Avoid tests that stop after the first case inside a loop. Use data providers where appropriate.
+
+Tests should be deterministic except where randomness is the behavior under test.
+
+## Static analysis and tooling
+
+Add standard tooling only when it materially improves confidence.
+
+Recommended project commands:
+
+- `composer test`
+- `composer lint`
+- `composer stan`
+- `composer cs-check`
+
+Reasonable tools:
+
+- PHPUnit for tests.
+- PHPStan or Psalm for static analysis.
+- PHP-CS-Fixer or PHP_CodeSniffer for style.
+- Composer validation.
+
+Tooling should be configured in the repo and runnable locally.
+
+Do not add heavyweight frameworks or unrelated build systems.
+
+## CI expectations
+
+CI should run on pull requests and pushes.
+
+CI should check:
+
+- Composer validation.
+- dependency installation.
+- PHP syntax linting.
+- unit tests.
+- static analysis.
+- coding style check if configured.
+
+Test against currently supported PHP versions for the package. Do not claim support for PHP versions not covered by CI.
+
+Keep CI boring and readable.
+
+## Documentation requirements
+
+Documentation should explain behavior, not market the package.
+
+Update docs when changing:
+
+- installation requirements,
+- PHP version support,
+- required extensions,
+- public API,
+- ciphertext format,
+- salt handling,
+- key handling,
+- migration path,
+- exception behavior,
+- test/tool commands.
+
+Security documentation should include:
+
+- what Cryptex protects,
+- what it does not protect,
+- key and salt guidance,
+- storage guidance,
+- tamper behavior,
+- legacy compatibility notes.
+
+Examples must be correct and copy-pasteable.
+
+Do not include toy secrets in examples without clearly marking them as examples.
+
+## Performance guidance
+
+This library should be efficient but not at the expense of security.
+
+- Avoid unnecessary dependencies.
+- Avoid unnecessary allocations where clarity is not harmed.
+- Do not prematurely optimize cryptographic code.
+- Keep KDF cost parameters defensible and documented.
+- Do not weaken Argon2id settings to make tests faster unless tests explicitly mock or isolate that cost.
+
+Performance-sensitive changes should be justified in comments, tests, or documentation.
+
+## Dependency policy
+
+Dependencies increase maintenance and supply-chain risk.
+
+Before adding a runtime dependency, ask:
+
+- Is this necessary?
+- Is it well maintained?
+- Does PHP or Sodium already provide this?
+- Can this be implemented more clearly in a few lines?
+- Does it increase the attack surface?
+
+Runtime dependencies should be close to zero.
+
+Development dependencies are acceptable when they improve tests, style, or analysis.
+
+## Coding style
+
+Prefer code that looks inevitable.
+
+- Short methods.
+- Clear names.
+- No clever branching.
+- No hidden global state.
+- No magic constants without names.
+- No comments that merely repeat code.
+- Comments should explain security decisions, format decisions, or non-obvious constraints.
+- Use constants for sizes, versions, and algorithm parameters.
+- Keep exception messages clear and stable.
+
+## Commit and PR expectations
+
+Each PR should include:
+
+- summary of changes,
+- security rationale if behavior changed,
+- backward compatibility notes,
+- test coverage notes,
+- commands run,
+- migration notes if applicable.
+
+Do not mix unrelated refactors with security-sensitive behavior changes unless necessary.
+
+Prefer small, reviewable commits.
+
+## Definition of done
+
+A change is done only when:
+
+- public behavior is intentional,
+- security-sensitive behavior is documented,
+- tests cover success and failure paths,
+- Composer metadata is accurate,
+- CI/tooling passes,
+- examples are updated,
+- legacy behavior is preserved or migration is documented,
+- the code is simpler or more trustworthy than before.
+
+The best final result is a library that feels uneventful: small surface area, obvious control flow, explicit formats, strong tests, and no surprises.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Cryptex is a simple PHP class that performs 2-way authenticated encryption using
 
 # Requirements
 
-* PHP 8.1 or newer
+* PHP 8.3 or newer
+* `ext-sodium`
 
 
 # Installation
@@ -74,13 +75,15 @@ if (hash_equals($plaintext, $result)) {
 
 The PHPUnit test class is in `tests/CryptexTest.php`.
 
-If you installed Cryptex with Composer, you can run the following command in the top-level folder of this project to perform the unit tests:
+If you installed Cryptex with Composer, you can run the following commands in the top-level folder of this project:
 
-`./vendor/bin/phpunit --bootstrap vendor/autoload.php tests`
+`composer test`
 
-If `phpunit` is already installed on your local system, you can run this command instead:
+`composer lint`
 
-`phpunit tests`
+The PHPUnit command used by `composer test` is:
+
+`./vendor/bin/phpunit --configuration phpunit.xml.dist`
 
 
 # Generating Documentation

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,19 @@
         }
     ],
     "require": {
-        "php": ">=8.1"
+        "php": ">=8.3",
+        "ext-sodium": "*"
     },
     "autoload": {
         "psr-4": {
             "cryptex\\": "src/"
         }
     },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --configuration phpunit.xml.dist",
+        "lint": "@php tools/lint.php"
+    },
     "require-dev": {
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "^12"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,91 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5152a681211d41257b1b1f22d247750f",
+    "content-hash": "089f2d151b2ff91198d5f2a11d152204",
     "packages": [],
     "packages-dev": [
         {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -96,11 +26,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -126,7 +57,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -134,29 +65,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -164,7 +97,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -188,26 +121,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -248,9 +182,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -305,35 +245,33 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.27",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
-                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/lines-of-code": "^4.0",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.5.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -342,7 +280,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -371,40 +309,52 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-07-26T13:44:30+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -431,36 +381,49 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -468,7 +431,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -494,7 +457,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -502,32 +466,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -553,7 +517,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -561,32 +526,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -612,7 +577,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -620,54 +586,49 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.10",
+            "version": "12.5.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
+                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
-                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d75dd30597caa80e72fad2ef7904601a30ef1046",
+                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.6",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.0",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.3",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "bin": [
                 "phpunit"
@@ -675,7 +636,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -707,48 +668,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.24"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2023-07-10T04:04:23+00:00"
+            "time": "2026-05-01T04:21:04+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -771,153 +724,60 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:08:49+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.2"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -956,41 +816,54 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1013,7 +886,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1021,33 +895,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1079,7 +953,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1087,27 +962,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1115,7 +990,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1134,7 +1009,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -1142,42 +1017,55 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1219,46 +1107,56 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -1277,47 +1175,60 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/97ffee3bcfb5805568d6af7f0f893678fc076d2f",
+                "reference": "97ffee3bcfb5805568d6af7f0f893678fc076d2f",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1340,7 +1251,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1348,34 +1260,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2025-02-07T04:57:28+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1397,7 +1309,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -1405,32 +1318,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1452,7 +1365,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -1460,32 +1374,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1515,95 +1429,53 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1626,37 +1498,50 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1679,7 +1564,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -1687,27 +1573,79 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -1729,7 +1667,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1737,17 +1675,18 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.3",
+        "ext-sodium": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
 >

--- a/src/Cryptex.php
+++ b/src/Cryptex.php
@@ -40,6 +40,10 @@ final class Cryptex
      */
     public static function encrypt(string $plaintext, string $key, string $salt): string
     {
+        $derivedKey = '';
+        $nonce = '';
+        $encryptedData = '';
+
         try {
             // Generate a derived binary key
             $derivedKey = self::generateDerivedKey($key, $salt);
@@ -68,10 +72,24 @@ final class Cryptex
             throw $e;
         } finally {
             // Wipe sensitive data
-            sodium_memzero($plaintext);
-            sodium_memzero($key);
-            sodium_memzero($salt);
-            sodium_memzero($derivedKey);
+            if ($plaintext !== '') {
+                sodium_memzero($plaintext);
+            }
+            if ($key !== '') {
+                sodium_memzero($key);
+            }
+            if ($salt !== '') {
+                sodium_memzero($salt);
+            }
+            if ($derivedKey !== '') {
+                sodium_memzero($derivedKey);
+            }
+            if ($nonce !== '') {
+                sodium_memzero($nonce);
+            }
+            if ($encryptedData !== '') {
+                sodium_memzero($encryptedData);
+            }
         }
     }
 
@@ -88,6 +106,11 @@ final class Cryptex
      */
     public static function decrypt(string $ciphertext, string $key, string $salt): string
     {
+        $derivedKey = '';
+        $decoded = '';
+        $nonce = '';
+        $encryptedPayload = '';
+
         try {
             // Generate a derived binary key
             $derivedKey = self::generateDerivedKey($key, $salt);
@@ -101,24 +124,21 @@ final class Cryptex
             }
 
             // Get the nonce value from the decoded data
-            $nonce = mb_substr(
+            $nonce = substr(
                 $decoded,
                 0,
-                self::NONCE_LENGTH,
-                '8bit'
+                self::NONCE_LENGTH
             );
 
             // Get the ciphertext from the decoded data
-            $ciphertext = mb_substr(
+            $encryptedPayload = substr(
                 $decoded,
-                self::NONCE_LENGTH,
-                null,
-                '8bit'
+                self::NONCE_LENGTH
             );
 
             // Decrypt the data
             $plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
-                $ciphertext,
+                $encryptedPayload,
                 '',
                 $nonce,
                 $derivedKey
@@ -134,9 +154,24 @@ final class Cryptex
             throw $e;
         } finally {
             // Wipe sensitive data
-            sodium_memzero($key);
-            sodium_memzero($salt);
-            sodium_memzero($derivedKey);
+            if ($key !== '') {
+                sodium_memzero($key);
+            }
+            if ($salt !== '') {
+                sodium_memzero($salt);
+            }
+            if ($derivedKey !== '') {
+                sodium_memzero($derivedKey);
+            }
+            if ($decoded !== '') {
+                sodium_memzero($decoded);
+            }
+            if ($nonce !== '') {
+                sodium_memzero($nonce);
+            }
+            if ($encryptedPayload !== '') {
+                sodium_memzero($encryptedPayload);
+            }
         }
     }
 
@@ -150,12 +185,9 @@ final class Cryptex
     public static function generateSalt(): string
     {
         try {
-            $salt = random_bytes(self::SALT_LENGTH);
-            return $salt;
+            return random_bytes(self::SALT_LENGTH);
         } catch (Exception $e) {
             throw $e;
-        } finally {
-            sodium_memzero($salt);
         }
     }
 
@@ -171,6 +203,8 @@ final class Cryptex
      */
     private static function generateDerivedKey(string $key, string $salt): string
     {
+        $derivedKey = '';
+
         try {
             // Salt length requirement check
             if (strlen($salt) !== self::SALT_LENGTH) {
@@ -194,9 +228,15 @@ final class Cryptex
             throw $e;
         } finally {
             // Wipe sensitive data
-            sodium_memzero($key);
-            sodium_memzero($salt);
-            sodium_memzero($derivedKey);
+            if ($key !== '') {
+                sodium_memzero($key);
+            }
+            if ($salt !== '') {
+                sodium_memzero($salt);
+            }
+            if ($derivedKey !== '') {
+                sodium_memzero($derivedKey);
+            }
         }
     }
 }

--- a/tests/CryptexTest.php
+++ b/tests/CryptexTest.php
@@ -1,155 +1,258 @@
 <?php
+
 namespace cryptex;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
+use SodiumException;
 
-/**
- * CryptexTest performs unit testing for the Cryptex class.
- *
- * @category Tests
- * @package Cryptex
- * @author Michael Mawhinney
- * @copyright 2023
- * @license https://opensource.org/licenses/MIT/ MIT
- * @version 4.0.0
- */
 final class CryptexTest extends TestCase
 {
-    /**
-     * @var string Key for encryption and decryption tests.
-     */
-    private $key;
+    private string $key;
 
-    /**
-     * @var string Salt for encryption and decryption tests.
-     */
-    private $salt;
+    private string $salt;
 
-    /**
-     * @var int Length of the salt value.
-     */
-    private $saltLength;
+    private string $plaintext;
 
-    /**
-     * @var string Plaintext string for encryption and decryption tests.
-     */
-    private $plaintext;
+    private string $ciphertext;
 
-    /**
-     * @var string Ciphertext string for encryption and decryption tests.
-     */
-    private $ciphertext;
-
-    /**
-     * Sets up each test by initializing required variables and generating encrypted data for decryption tests.
-     */
     protected function setUp(): void
     {
-        // Access the private vars with reflection
-        $reflection = new ReflectionClass(Cryptex::class);
-        $this->saltLength = $reflection->getReflectionConstant('SALT_LENGTH')->getValue();
-
-        // Set the remaining vars
         $this->key = '1-2-3-4-5';
         $this->salt = Cryptex::generateSalt();
         $this->plaintext = "You're a certified prince.";
         $this->ciphertext = Cryptex::encrypt($this->plaintext, $this->key, $this->salt);
     }
 
-    /**
-     * Tests the `generateSalt()` method.
-     */
-    public function testGenerateSalt(): void
+    public function testGenerateSaltReturnsExpectedLength(): void
     {
-        $this->assertIsInt($this->saltLength);
-        $this->assertIsString($this->salt);
-        $this->assertEquals($this->saltLength, strlen($this->salt));
+        $salt = Cryptex::generateSalt();
+
+        $this->assertSame(SODIUM_CRYPTO_PWHASH_SALTBYTES, strlen($salt));
     }
 
-    /**
-     * Tests the `encrypt()` and `decrypt()` methods with valid inputs.
-     */
-    public function testEncryptDecrypt(): void
+    public function testEncryptDecryptRoundTrip(): void
     {
-        $this->assertIsString($this->ciphertext);
-        $this->assertNotEquals($this->plaintext, $this->ciphertext);
-
         $decrypted = Cryptex::decrypt($this->ciphertext, $this->key, $this->salt);
-        $this->assertEquals($this->plaintext, $decrypted);
+
+        $this->assertNotSame($this->plaintext, $this->ciphertext);
+        $this->assertSame($this->plaintext, $decrypted);
+    }
+
+    public function testRepeatedEncryptionProducesDifferentCiphertext(): void
+    {
+        $otherCiphertext = Cryptex::encrypt($this->plaintext, $this->key, $this->salt);
+
+        $this->assertNotSame($this->ciphertext, $otherCiphertext);
     }
 
     /**
-     * Tests the `encrypt()` and `decrypt()` methods with invalid input values.
+     * @dataProvider invalidSaltLengthProvider
      */
-    public function testEncryptDecryptWithInvalidInput(): void
+    #[DataProvider('invalidSaltLengthProvider')]
+    public function testEncryptRejectsInvalidSaltLength(string $salt): void
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(SaltLengthException::class);
 
-        $invalidInputs = [null, '', [], new \stdClass(), true];
-        foreach ($invalidInputs as $invalidInput) {
-            Cryptex::encrypt($invalidInput, $this->key, $this->salt);
-            Cryptex::decrypt($invalidInput, $this->key, $this->salt);
-        }
+        Cryptex::encrypt($this->plaintext, $this->key, $salt);
     }
 
     /**
-     * Tests the `encrypt()` and `decrypt()` methods with invalid key or salt.
+     * @dataProvider invalidSaltLengthProvider
      */
-    public function testEncryptDecryptWithInvalidKeyOrSalt(): void
+    #[DataProvider('invalidSaltLengthProvider')]
+    public function testDecryptRejectsInvalidSaltLength(string $salt): void
     {
-        $this->expectException(\TypeError::class);
-        $invalidInputs = [null, '', [], new \stdClass(), true, 'invalid'];
-        foreach ($invalidInputs as $invalidInput) {
-            Cryptex::encrypt($this->ciphertext, $invalidInput, $this->salt);
-            Cryptex::decrypt($this->ciphertext, $invalidInput, $this->salt);
-            Cryptex::encrypt($this->ciphertext, $this->key, $invalidInput);
-            Cryptex::decrypt($this->ciphertext, $this->key, $invalidInput);
-        }
+        $this->expectException(SaltLengthException::class);
+
+        Cryptex::decrypt($this->ciphertext, $this->key, $salt);
     }
 
-    /**
-     * Tests the `decrypt()` method with invalid ciphertext.
-     */
-    public function testDecryptWithInvalidCiphertext(): void
+    public function testDecryptRejectsWrongKey(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(DecryptionException::class);
+
+        Cryptex::decrypt($this->ciphertext, 'wrong-key', $this->salt);
+    }
+
+    public function testDecryptRejectsWrongSalt(): void
+    {
+        $this->expectException(DecryptionException::class);
+
+        Cryptex::decrypt($this->ciphertext, $this->key, Cryptex::generateSalt());
+    }
+
+    public function testDecryptRejectsTamperedCiphertext(): void
+    {
+        $tamperedCiphertext = $this->flipLastHexNibble($this->ciphertext);
+
+        $this->expectException(DecryptionException::class);
+
+        Cryptex::decrypt($tamperedCiphertext, $this->key, $this->salt);
+    }
+
+    public function testDecryptRejectsMalformedHexCiphertext(): void
+    {
+        $this->expectException(SodiumException::class);
+
         Cryptex::decrypt('invalid ciphertext', $this->key, $this->salt);
     }
 
-    /**
-     * Tests the `encrypt()` and `decrypt()` methods with a large plaintext string.
-     */
-    public function testLargePlaintext(): void
+    public function testDecryptRejectsTooShortPayload(): void
     {
-        $largePlaintext = str_repeat('x', 1000000); // 1 million characters
-        $ciphertext = Cryptex::encrypt($largePlaintext, $this->key, $this->salt);
-        $decrypted = Cryptex::decrypt($ciphertext, $this->key, $this->salt);
+        $this->expectException(NonceLengthException::class);
 
-        $this->assertEquals($largePlaintext, $decrypted);
+        Cryptex::decrypt('aa', $this->key, $this->salt);
+    }
+
+    public function testEncryptDecryptEmptyPlaintext(): void
+    {
+        $plaintext = '';
+        $ciphertext = Cryptex::encrypt($plaintext, $this->key, $this->salt);
+
+        $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $this->key, $this->salt));
+    }
+
+    public function testEncryptDecryptBinaryPlaintext(): void
+    {
+        $plaintext = "\x00\x01\x02binary\x00text\xff";
+        $ciphertext = Cryptex::encrypt($plaintext, $this->key, $this->salt);
+
+        $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $this->key, $this->salt));
+    }
+
+    public function testEncryptDecryptNonAsciiPlaintext(): void
+    {
+        $plaintext = 'naive cafe 漢字';
+        $ciphertext = Cryptex::encrypt($plaintext, $this->key, $this->salt);
+
+        $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $this->key, $this->salt));
+    }
+
+    public function testEncryptDecryptLargePlaintext(): void
+    {
+        $plaintext = str_repeat('x', 1000000);
+        $ciphertext = Cryptex::encrypt($plaintext, $this->key, $this->salt);
+
+        $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $this->key, $this->salt));
     }
 
     /**
-     * Tests the `encrypt()` and `decrypt()` methods with a plaintext string that contains non-alphanumeric characters.
+     * @dataProvider invalidPlaintextProvider
      */
-    public function testNonAlphanumericCharacters(): void
+    #[DataProvider('invalidPlaintextProvider')]
+    public function testEncryptRejectsInvalidPlaintextTypes($plaintext): void
     {
-        $nonAlphanumericPlaintext = '!@#$%^&*(){}[]:;"<>,.?/~`|-_=+\\';
-        $ciphertext = Cryptex::encrypt($nonAlphanumericPlaintext, $this->key, $this->salt);
-        $decrypted = Cryptex::decrypt($ciphertext, $this->key, $this->salt);
+        $this->expectException(\TypeError::class);
 
-        $this->assertEquals($nonAlphanumericPlaintext, $decrypted);
+        Cryptex::encrypt($plaintext, $this->key, $this->salt);
     }
 
     /**
-     * Tests the `encrypt()` and `decrypt()` methods with a key that contains non-alphanumeric characters.
+     * @dataProvider invalidCiphertextProvider
      */
-    public function testKeyNonAlphanumericCharacters(): void
+    #[DataProvider('invalidCiphertextProvider')]
+    public function testDecryptRejectsInvalidCiphertextTypes($ciphertext): void
     {
-        $nonAlphanumericKey = '!@#$%^&*(){}[]:;"<>,.?/~`|-_=+\\';
-        $ciphertext = Cryptex::encrypt($this->plaintext, $nonAlphanumericKey, $this->salt);
-        $decrypted = Cryptex::decrypt($ciphertext, $nonAlphanumericKey, $this->salt);
+        $this->expectException(\TypeError::class);
 
-        $this->assertEquals($this->plaintext, $decrypted);
+        Cryptex::decrypt($ciphertext, $this->key, $this->salt);
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    #[DataProvider('invalidKeyProvider')]
+    public function testEncryptRejectsInvalidKeyTypes($key): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Cryptex::encrypt($this->plaintext, $key, $this->salt);
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    #[DataProvider('invalidKeyProvider')]
+    public function testDecryptRejectsInvalidKeyTypes($key): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Cryptex::decrypt($this->ciphertext, $key, $this->salt);
+    }
+
+    /**
+     * @dataProvider invalidSaltTypeProvider
+     */
+    #[DataProvider('invalidSaltTypeProvider')]
+    public function testEncryptRejectsInvalidSaltTypes($salt): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Cryptex::encrypt($this->plaintext, $this->key, $salt);
+    }
+
+    /**
+     * @dataProvider invalidSaltTypeProvider
+     */
+    #[DataProvider('invalidSaltTypeProvider')]
+    public function testDecryptRejectsInvalidSaltTypes($salt): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Cryptex::decrypt($this->ciphertext, $this->key, $salt);
+    }
+
+    public static function invalidPlaintextProvider(): array
+    {
+        return [
+            'null' => [null],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    public static function invalidCiphertextProvider(): array
+    {
+        return [
+            'null' => [null],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    public static function invalidKeyProvider(): array
+    {
+        return [
+            'null' => [null],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    public static function invalidSaltTypeProvider(): array
+    {
+        return [
+            'null' => [null],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+        ];
+    }
+
+    public static function invalidSaltLengthProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'short' => ['short'],
+            'long' => [str_repeat('a', SODIUM_CRYPTO_PWHASH_SALTBYTES + 1)],
+        ];
+    }
+
+    private function flipLastHexNibble(string $hex): string
+    {
+        $lastNibble = substr($hex, -1);
+        $replacement = $lastNibble === '0' ? '1' : '0';
+
+        return substr($hex, 0, -1) . $replacement;
     }
 }

--- a/tools/lint.php
+++ b/tools/lint.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+$paths = [
+    __DIR__ . '/../src',
+    __DIR__ . '/../tests',
+];
+
+$hasErrors = false;
+
+foreach ($paths as $path) {
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if (!$file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $command = escapeshellarg(PHP_BINARY) . ' -l ' . escapeshellarg($file->getPathname());
+        passthru($command, $exitCode);
+
+        if ($exitCode !== 0) {
+            $hasErrors = true;
+        }
+    }
+}
+
+exit($hasErrors ? 1 : 0);


### PR DESCRIPTION
## Summary

This PR establishes a modern verification baseline for Cryptex while preserving the existing v4 public API, ciphertext format, and salt semantics.

It intentionally does **not** redesign the encryption format or introduce a new v5 API. The goal is to make the current behavior measurable, supported, and easier to safely harden in follow-up PRs.

## What changed

- Raised the PHP support floor to PHP 8.3 or newer.
- Declared `ext-sodium` as an explicit runtime requirement.
- Updated PHPUnit to `^12`.
- Regenerated `composer.lock`.
- Added Composer scripts for common local checks:
  - `composer test`
  - `composer lint`
- Added a small PHP lint runner under `tools/lint.php`.
- Expanded PHPUnit coverage around current v4 behavior, including:
  - successful round trips
  - repeated encryption producing different ciphertext
  - generated salt length
  - invalid salt length
  - wrong key failure
  - wrong salt failure
  - tampered ciphertext failure
  - malformed hex failure
  - too-short payload failure
  - empty plaintext
  - binary plaintext
  - non-ASCII plaintext
  - large plaintext
  - invalid argument types via data providers
- Updated CI to test PHP 8.3, 8.4, and 8.5.
- Updated GitHub Actions dependencies to Node 24-compatible versions.
- Updated README requirements and testing instructions.

## Minimal source cleanup

This PR includes a small number of behavior-preserving source changes:

- Replaced `mb_substr()` with `substr()` for binary slicing.
- Avoided the implicit `mbstring` dependency in the library source.
- Guarded `sodium_memzero()` cleanup calls so cleanup does not mask the intended exception.
- Stopped wiping the generated salt immediately before returning it.

These changes are intended to preserve the existing encryption/decryption behavior while making the current implementation easier to test reliably.

## Explicitly out of scope

This PR does not:

- change the ciphertext format
- introduce a versioned envelope
- switch to base64url
- change salt handling
- add AAD
- redesign the public API
- split the library into multiple classes
- perform a full source hardening pass

Those should be handled in separate, focused PRs.

## Verification

Local checks run:

- [x] `composer validate`
- [x] `composer lint`
- [x] `composer test`

CI should also verify the test matrix across PHP 8.3, 8.4, and 8.5.

## Rationale

PHP 8.3 is a reasonable new support floor because it remains security-supported through December 31, 2027. The CI matrix now covers PHP 8.3, 8.4, and 8.5.

GitHub Actions is also moving away from Node 20, so this PR updates workflow actions to current Node 24-compatible versions.

## Follow-up work

Recommended next PR:

- add `declare(strict_types=1);`
- clean up exception handling
- remove redundant catch/rethrow blocks
- improve decoding and length validation
- simplify and clarify memory cleanup
- keep legacy v4 behavior covered by tests before any format migration