### PR TITLE
Harden v4 Cryptex implementation

### DIFF
--- a/src/Cryptex.php
+++ b/src/Cryptex.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace cryptex;
 
 /**
@@ -18,15 +21,10 @@ namespace cryptex;
  */
 final class Cryptex
 {
-    /**
-     * @var int  Required length of the nonce value
-     */
     private const NONCE_LENGTH = \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES;
-
-    /**
-     * @var int  Required length of the salt value
-     */
     private const SALT_LENGTH = \SODIUM_CRYPTO_PWHASH_SALTBYTES;
+    private const TAG_LENGTH = \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES;
+    private const MINIMUM_DECODED_PAYLOAD_LENGTH = self::NONCE_LENGTH + self::TAG_LENGTH;
 
     /**
      * Encrypts data using XChaCha20 + Poly1305 (from the Sodium crypto library).
@@ -37,59 +35,30 @@ final class Cryptex
      * @return string Encrypted data (hex-encoded).
      *
      * @throws EncryptionException If the data encryption fails.
+     * @throws SaltLengthException If the salt is not the expected length.
+     * @throws \Random\RandomException If an error occurs while generating the nonce.
+     * @throws \SodiumException If a lower-level Sodium call fails.
      */
     public static function encrypt(string $plaintext, string $key, string $salt): string
     {
         $derivedKey = '';
-        $nonce = '';
-        $encryptedData = '';
-
         try {
-            // Generate a derived binary key
             $derivedKey = self::generateDerivedKey($key, $salt);
-
-            // Generate a nonce value of the correct size
             $nonce = random_bytes(self::NONCE_LENGTH);
-
-            // Encrypt the data
-            $encryptedData = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
+            $encryptedPayload = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
                 $plaintext,
                 '',
                 $nonce,
                 $derivedKey
             );
-            if ($encryptedData === false) {
+
+            if ($encryptedPayload === false) {
                 throw new EncryptionException('Failed to encrypt the data');
             }
 
-            // Prepend the nonce, and hex encode
-            $ciphertext = sodium_bin2hex($nonce . $encryptedData);
-
-            // Return the encrypted data
-            return $ciphertext;
-        } catch (Exception $e) {
-            // Rethrow the exception
-            throw $e;
+            return sodium_bin2hex($nonce . $encryptedPayload);
         } finally {
-            // Wipe sensitive data
-            if ($plaintext !== '') {
-                sodium_memzero($plaintext);
-            }
-            if ($key !== '') {
-                sodium_memzero($key);
-            }
-            if ($salt !== '') {
-                sodium_memzero($salt);
-            }
-            if ($derivedKey !== '') {
-                sodium_memzero($derivedKey);
-            }
-            if ($nonce !== '') {
-                sodium_memzero($nonce);
-            }
-            if ($encryptedData !== '') {
-                sodium_memzero($encryptedData);
-            }
+            self::wipeBuffer($derivedKey);
         }
     }
 
@@ -101,77 +70,39 @@ final class Cryptex
      * @param string $salt Salt value.
      * @return string Unencrypted data.
      *
+     * @throws SaltLengthException If the salt is not the expected length.
      * @throws NonceLengthException If the decoded data is not the expected length.
      * @throws DecryptionException If the data decryption fails.
+     * @throws \SodiumException If the ciphertext is malformed hex or a lower-level Sodium call fails.
      */
     public static function decrypt(string $ciphertext, string $key, string $salt): string
     {
         $derivedKey = '';
-        $decoded = '';
-        $nonce = '';
-        $encryptedPayload = '';
-
         try {
-            // Generate a derived binary key
             $derivedKey = self::generateDerivedKey($key, $salt);
+            $decodedPayload = sodium_hex2bin($ciphertext);
 
-            // Hex decode
-            $decoded = sodium_hex2bin($ciphertext);
-
-            // Check the decoded length
-            if (strlen($decoded) < self::NONCE_LENGTH) {
-                throw new NonceLengthException('Decoded data is not the expected length');
+            if (strlen($decodedPayload) < self::MINIMUM_DECODED_PAYLOAD_LENGTH) {
+                throw new NonceLengthException('Decoded data is shorter than the minimum payload length');
             }
 
-            // Get the nonce value from the decoded data
-            $nonce = substr(
-                $decoded,
-                0,
-                self::NONCE_LENGTH
-            );
+            $nonce = substr($decodedPayload, 0, self::NONCE_LENGTH);
+            $encryptedPayload = substr($decodedPayload, self::NONCE_LENGTH);
 
-            // Get the ciphertext from the decoded data
-            $encryptedPayload = substr(
-                $decoded,
-                self::NONCE_LENGTH
-            );
-
-            // Decrypt the data
             $plaintext = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt(
                 $encryptedPayload,
                 '',
                 $nonce,
                 $derivedKey
             );
+
             if ($plaintext === false) {
                 throw new DecryptionException('Failed to decrypt the data');
             }
 
-            // Return the decrypted data
             return $plaintext;
-        } catch (Exception $e) {
-            // Rethrow the exception
-            throw $e;
         } finally {
-            // Wipe sensitive data
-            if ($key !== '') {
-                sodium_memzero($key);
-            }
-            if ($salt !== '') {
-                sodium_memzero($salt);
-            }
-            if ($derivedKey !== '') {
-                sodium_memzero($derivedKey);
-            }
-            if ($decoded !== '') {
-                sodium_memzero($decoded);
-            }
-            if ($nonce !== '') {
-                sodium_memzero($nonce);
-            }
-            if ($encryptedPayload !== '') {
-                sodium_memzero($encryptedPayload);
-            }
+            self::wipeBuffer($derivedKey);
         }
     }
 
@@ -180,15 +111,11 @@ final class Cryptex
      *
      * @return string Random salt value of length SODIUM_CRYPTO_PWHASH_SALTBYTES.
      *
-     * @throws Exception If an error occurs while generating the salt value.
+     * @throws \Random\RandomException If an error occurs while generating the salt value.
      */
     public static function generateSalt(): string
     {
-        try {
-            return random_bytes(self::SALT_LENGTH);
-        } catch (Exception $e) {
-            throw $e;
-        }
+        return random_bytes(self::SALT_LENGTH);
     }
 
     /**
@@ -199,45 +126,39 @@ final class Cryptex
      * @return string Derived binary key.
      *
      * @throws SaltLengthException If the salt is not the expected length.
-     * @throws Exception If an error occurs while generating the derived binary key.
+     * @throws \SodiumException If an error occurs while generating the derived binary key.
      */
     private static function generateDerivedKey(string $key, string $salt): string
     {
-        $derivedKey = '';
+        self::assertValidSaltLength($salt);
 
-        try {
-            // Salt length requirement check
-            if (strlen($salt) !== self::SALT_LENGTH) {
-                throw new SaltLengthException('Salt is not the expected length');
-            }
+        return sodium_crypto_pwhash(
+            \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES,
+            $key,
+            $salt,
+            \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
+            \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE,
+            \SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13
+        );
+    }
 
-            // Generate the derived binary key
-            $derivedKey = sodium_crypto_pwhash(
-                SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES,
-                $key,
-                $salt,
-                SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE,
-                SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE,
-                SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13
-            );
-
-            // Return the derived binary key
-            return $derivedKey;
-        } catch (Exception $e) {
-            // Rethrow the exception
-            throw $e;
-        } finally {
-            // Wipe sensitive data
-            if ($key !== '') {
-                sodium_memzero($key);
-            }
-            if ($salt !== '') {
-                sodium_memzero($salt);
-            }
-            if ($derivedKey !== '') {
-                sodium_memzero($derivedKey);
-            }
+    /**
+     * @throws SaltLengthException If the salt is not the expected length.
+     */
+    private static function assertValidSaltLength(string $salt): void
+    {
+        if (strlen($salt) !== self::SALT_LENGTH) {
+            throw new SaltLengthException('Salt is not the expected length');
         }
+    }
+
+    private static function wipeBuffer(string &$buffer): void
+    {
+        if ($buffer === '') {
+            return;
+        }
+
+        sodium_memzero($buffer);
     }
 }
 

--- a/tests/CryptexTest.php
+++ b/tests/CryptexTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace cryptex;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -103,6 +105,25 @@ final class CryptexTest extends TestCase
         $this->expectException(NonceLengthException::class);
 
         Cryptex::decrypt('aa', $this->key, $this->salt);
+    }
+
+    public function testDecryptRejectsNonceOnlyPayload(): void
+    {
+        $nonceOnlyPayload = sodium_bin2hex(random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES));
+
+        $this->expectException(NonceLengthException::class);
+
+        Cryptex::decrypt($nonceOnlyPayload, $this->key, $this->salt);
+    }
+
+    public function testDecryptRejectsNoncePlusTooShortTagPayload(): void
+    {
+        $payload = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES)
+            . str_repeat("\x00", SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES - 1);
+
+        $this->expectException(NonceLengthException::class);
+
+        Cryptex::decrypt(sodium_bin2hex($payload), $this->key, $this->salt);
     }
 
     public function testEncryptDecryptEmptyPlaintext(): void


### PR DESCRIPTION
## Summary

This PR hardens the existing v4 Cryptex implementation without changing the public API, ciphertext format, or salt semantics.

It is intentionally limited to source-level correctness, clarity, and failure-mode hardening. It does **not** introduce a v5 envelope, base64url encoding, AAD support, or any public API redesign.

## What changed

- Added `declare(strict_types=1);` to source and tests.
- Simplified `encrypt()` and `decrypt()` control flow.
- Removed redundant catch-and-rethrow blocks.
- Removed accidental unqualified `Exception` usage inside the `cryptex` namespace.
- Added explicit payload-size constants:
  - nonce length
  - salt length
  - Poly1305 tag length
  - minimum decoded payload length
- Added minimum decoded payload validation before slicing.
- Kept binary slicing with `substr()`.
- Centralized salt-length validation.
- Simplified sensitive-buffer cleanup to wipe only the derived key.
- Avoided wiping caller-owned inputs or values returned to the caller.

## Test coverage

This PR preserves the existing v4 behavior coverage and adds hardening cases for malformed decoded payloads.

Covered behavior includes:

- successful encrypt/decrypt round trip
- repeated encryption producing different ciphertext
- generated salt length
- invalid salt length
- wrong key failure
- wrong salt failure
- tampered ciphertext failure
- malformed hex failure
- too-short payload failure
- nonce-only payload failure
- nonce-plus-short-tag payload failure
- empty plaintext
- binary plaintext
- non-ASCII plaintext
- large plaintext
- invalid argument types via data providers

## Behavior preservation

This PR preserves:

- `Cryptex::encrypt(string $plaintext, string $key, string $salt): string`
- `Cryptex::decrypt(string $ciphertext, string $key, string $salt): string`
- `Cryptex::generateSalt(): string`
- the current v4 hex ciphertext format
- the current external salt requirement
- the current use of XChaCha20-Poly1305 via libsodium
- the current Argon2id key-derivation approach

## Explicitly out of scope

This PR does not:

- introduce a versioned ciphertext envelope
- switch ciphertext encoding to base64url
- embed salts in ciphertext
- change salt semantics
- add AAD support
- add new public APIs
- split the library into multiple classes
- add runtime dependencies
- redesign the package structure

## Verification

Local checks run:

- [x] `composer validate`
- [x] `composer lint`
- [x] `composer test`

Result:

- `composer test` passed with 38 tests and 39 assertions.

## Follow-up work

Recommended next steps:

- Documentation-only pass to align README/API wording with the hardened exception and payload-validation behavior.
- Separate v5 design PR for a versioned ciphertext envelope and possible base64url format.
- Separate migration plan for legacy v4 hex payload compatibility if/when a v5 format is introduced.