### PR TITLE
Run docs deployment on main pushes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,10 @@
 name: Generate Docs and Deploy to Pages
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -18,8 +17,6 @@ concurrency:
 
 jobs:
   generate-and-deploy:
-    # Only run if PR is merged
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       # Checkout main branch


### PR DESCRIPTION
## Summary

This updates the docs deployment workflow to run on pushes to `main` instead of merged pull request events.

The previous `pull_request: closed` trigger could run with a read-only `GITHUB_TOKEN` for fork-based PRs, causing the `github-actions[bot]` push to `docs-ci` to fail with a 403.

## Changes

- Trigger docs deployment on `push` to `main`.
- Add `workflow_dispatch` for manual runs.
- Remove the merged-PR condition.

## Behavior

Docs are still generated from `main`, committed to `docs-ci`, uploaded as a Pages artifact, and deployed to GitHub Pages.