### PR TITLE
Limit docs deployment to canonical repository

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   generate-and-deploy:
+    if: github.repository == 'michaelmawhinney/cryptex'
     runs-on: ubuntu-latest
     steps:
       # Checkout main branch


### PR DESCRIPTION
## Summary

This prevents the docs deployment workflow from running in forks.

The canonical repository has GitHub Pages configured, but development forks may not. Without this guard, `actions/configure-pages` can fail in forks with `Get Pages site failed`.

## Changes

- Add a job-level guard so docs deployment only runs in `michaelmawhinney/cryptex`.

## Behavior

- Docs deployment still runs in the canonical repository.
- Forks skip the deployment job instead of failing.