### PR TITLE
Prepare v5.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## [5.0.0] - 2026-05-08
+
+Cryptex 5.0.0 is a modernization and hardening release. It raises the supported runtime floor while preserving the existing cryptographic behavior and public API.
+
+### Changed
+
+- Requires PHP 8.3 or newer.
+- Requires `ext-sodium`.
+- Standardizes the test baseline on PHPUnit 12.
+- Expands behavior coverage for success and failure cases.
+- Includes hardening work in the v4 implementation.
+- Reflects the repository main-branch rename to `main`.
+- Aligns with the current GitHub Actions and GitHub Pages workflow setup.
+
+### Compatibility
+
+- The v4 public API is preserved.
+- The v4 hex ciphertext format is preserved.
+- External salt semantics are preserved.
+- Existing v4-style ciphertext remains supported.
+
+### Not Introduced
+
+- No versioned ciphertext envelope.
+- No base64url encoding.
+- No embedded salts.
+- No AAD support.
+- No new public API.
+
+### Release Notes
+
+This release is a modernization and hardening update, not a ciphertext-format migration.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 Cryptex is a simple PHP class that performs 2-way authenticated encryption using XChaCha20 + Poly1305.
 
+Version 5.0.0 is a modernization and hardening release. It keeps the v4 public API, the v4 hex ciphertext format, and external salt semantics intact.
+
 
 # Requirements
 
 * PHP 8.3 or newer
 * `ext-sodium`
+
+These requirements apply to v5.0.0 and later. Existing v4-style ciphertexts remain decryptable with the same API, but v5 does not introduce a new ciphertext envelope or transport encoding.
 
 
 # Installation
@@ -39,12 +43,12 @@ try {
     // Generate a secure random salt value
     $salt = Cryptex::generateSalt();
 
-    // Encrypt the plaintext
+    // Encrypt the plaintext using the preserved v4-style API and hex ciphertext output
     $ciphertext = Cryptex::encrypt($plaintext, $key, $salt);
     // example result: 
     // 4c406399a8830dbf670832b298980280d71bfb8cba53246ed45c9b6e6fc753bc100da3d10d4bf0d406d8afd18b8a5a79f44e50424ed0970914490706418c5725258e
 
-    // Decrypt the ciphertext
+    // Decrypt the ciphertext with the same v4-style API
     $result = Cryptex::decrypt($ciphertext, $key, $salt);
 
 } catch (Exception $e) {
@@ -69,6 +73,10 @@ if (hash_equals($plaintext, $result)) {
 
 // The above example will output: Pass
 ```
+
+## Release Notes
+
+See [CHANGELOG.md](CHANGELOG.md) for the v5.0.0 release summary and compatibility notes.
 
 
 # Testing

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,24 @@
+# Cryptex v5.0.0 Release Notes
+
+Cryptex 5.0.0 is a modernization and hardening release.
+
+## Highlights
+
+- Requires PHP 8.3 or newer.
+- Requires `ext-sodium`.
+- Uses a modernized PHPUnit 12 test baseline.
+- Expands behavior coverage around encryption and decryption.
+- Preserves the v4 public API.
+- Preserves the v4 hex ciphertext format.
+- Preserves external salt semantics.
+- Includes hardening work in the v4 implementation.
+- Reflects the repository main-branch rename to `main`.
+- Matches the current GitHub Actions and GitHub Pages workflow setup.
+
+## Compatibility
+
+Existing v4-style ciphertext continues to work with the same API. This release does not introduce a versioned ciphertext envelope, base64url encoding, embedded salts, AAD, or a new public API.
+
+## Summary
+
+This is a major release for the new PHP/platform baseline, not a ciphertext-format migration.


### PR DESCRIPTION
## Summary

This PR prepares the documentation for the Cryptex v5.0.0 release.

v5.0.0 is a modernization and hardening release for the new PHP/platform baseline. It is **not** a ciphertext-format migration.

## What changed

- Added `CHANGELOG.md` with a v5.0.0 entry.
- Added `RELEASE_NOTES.md` with GitHub Releases-ready notes.
- Updated `README.md` to clarify the v5.0.0 compatibility story.
- Documented the PHP 8.3+ and `ext-sodium` requirements.
- Documented that v5.0.0 preserves:
  - the v4 public API
  - the v4 hex ciphertext format
  - external salt semantics
  - existing v4-style ciphertext compatibility

## Explicitly not introduced

This release does not introduce:

- a versioned ciphertext envelope
- base64url encoding
- embedded salts
- AAD support
- a new public API

## Verification

Local checks run:

- [x] `composer validate`
- [x] `composer lint`
- [x] `composer test`

## Release plan

After this PR is merged, tag the merged `main` branch as `v5.0.0` and create a GitHub Release using `RELEASE_NOTES.md`.