### PR TITLE
Harden ciphertext validation, autoloading, and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,21 +18,35 @@ jobs:
         php-version: ['8.3', '8.4', '8.5']
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-      - uses: shivammathur/setup-php@v2
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: sodium
           coverage: none
 
-      - uses: ramsey/composer-install@v4
-
       - name: Validate composer files
-        run: composer validate
+        run: composer validate --strict
+
+      - name: Audit locked dependencies
+        run: composer audit --locked
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Lint PHP files
         run: composer lint
+
+      - name: Check coding style
+        run: composer cs-check
+
+      - name: Run static analysis
+        run: composer stan
 
       - name: Run PHPUnit
         run: composer test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,55 +6,46 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
-  generate-and-deploy:
+  build:
     if: github.repository == 'michaelmawhinney/cryptex'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      # Checkout main branch
       - name: Checkout main branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
+          persist-credentials: false
 
-      # Generate docs using phpDocumentor
       - name: Build with phpDocumentor
         run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -vv --directory src,tests --target docs
 
-      # Configure git with an email and username
-      - name: Configure git
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-
-      # Recreate the docs-ci branch and push new docs
-      - name: Push to docs-ci branch
-        run: |
-          git fetch
-          git checkout -b docs-ci
-          git add docs/*
-          git commit -m "Generate docs after commit ${GITHUB_SHA} at $(date +'%Y-%m-%d %H:%M:%S %Z')"
-          git push -f origin docs-ci
-
-      # Configure GitHub Pages
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-
-      # Upload the generated docs static files as an artifact
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
 
-      # Deploy the artifact to GitHub Pages
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v5
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- Rejects invalid salt lengths, malformed hexadecimal ciphertext, and decoded payloads that are too short before running Argon2id during decryption.
+- Adds explicit regression coverage for nonce, ciphertext, and authentication-tag tampering.
+
+### Changed
+
+- Makes every public exception class independently PSR-4 autoloadable while preserving its name and inheritance.
+- Adds a fixed v4 ciphertext compatibility fixture.
+- Adds PHPStan, PHP_CodeSniffer, dependency auditing, and the corresponding CI checks.
+- Removes the documentation branch force-push and deploys GitHub Pages from an artifact with least-privilege job permissions.
+
+### Compatibility
+
+- Preserves the public API, namespaces, exception behavior, v4/v5 hexadecimal ciphertext format, external salts, and historical ciphertext decryption.
+- Does not add a ciphertext-size limit; applications should enforce suitable limits on untrusted input.
+
 ## [5.0.0] - 2026-05-08
 
 Cryptex 5.0.0 is a modernization and hardening release. It raises the supported runtime floor while preserving the existing cryptographic behavior and public API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Compatibility
 
-- Preserves the public API, namespaces, exception behavior, v4/v5 hexadecimal ciphertext format, external salts, and fixed v4-format compatibility fixture decryption.
+- Preserves the public API, namespaces, exception behavior, v4/v5 hexadecimal ciphertext format, external salts, and decryption of the fixed v4-format compatibility fixture.
 - Does not add a ciphertext-size limit; applications should enforce suitable limits on untrusted input.
 
 ## [5.0.0] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Compatibility
 
-- Preserves the public API, namespaces, exception behavior, v4/v5 hexadecimal ciphertext format, external salts, and historical ciphertext decryption.
+- Preserves the public API, namespaces, exception behavior, v4/v5 hexadecimal ciphertext format, external salts, and fixed v4-format compatibility fixture decryption.
 - Does not add a ciphertext-size limit; applications should enforce suitable limits on untrusted input.
 
 ## [5.0.0] - 2026-05-08

--- a/README.md
+++ b/README.md
@@ -1,103 +1,127 @@
-<img src="https://michaelmawhinney.com/cryptex/logo.gif" width="300px">
+<img src="https://michaelmawhinney.com/cryptex/logo.gif" width="300" alt="Cryptex">
 
-# Cryptex: 2-way Authenticated Encryption Class
+# Cryptex: authenticated symmetric encryption
 
-Cryptex is a simple PHP class that performs 2-way authenticated encryption using XChaCha20 + Poly1305.
+Cryptex is a small PHP library for authenticated encryption using XChaCha20-Poly1305 and Argon2id from PHP's Sodium extension.
 
-Version 5.0.0 is a modernization and hardening release. It keeps the v4 public API, the v4 hex ciphertext format, and external salt semantics intact.
+Version 5 preserves the v4 public API, hex ciphertext format, and external-salt behavior. Existing v4-style ciphertext remains decryptable with the same key and salt.
 
+## Requirements
 
-# Requirements
+- PHP 8.3 or newer
+- `ext-sodium`
 
-* PHP 8.3 or newer
-* `ext-sodium`
+## Installation
 
-These requirements apply to v5.0.0 and later. Existing v4-style ciphertexts remain decryptable with the same API, but v5 does not introduce a new ciphertext envelope or transport encoding.
+Install the package with Composer:
 
+```console
+composer require michaelmawhinney/cryptex
+```
 
-# Installation
+Composer autoloading is recommended. If Composer is unavailable, `src/Cryptex.php` can still be required directly; it loads the public exception classes it needs.
 
-The preferred method of installation is with Packagist and Composer. The following command installs the package and adds it as a requirement to your project's composer.json:
+## Usage
 
-`composer require michaelmawhinney/cryptex`
-
-You can also download or clone the repo and include the `src/Cryptex.php` manually if you prefer.
-
-
-# Usage
-
-**Always store or transmit your `$key` and `$salt` values securely.**
+Generate random key material once and store it in a secret manager or another protected location. Generate and retain the external salt for each encrypted value because the salt is required for decryption.
 
 ```php
 <?php
+
+declare(strict_types=1);
+
 require 'vendor/autoload.php';
 
 use cryptex\Cryptex;
 
-try {
+$plaintext = "You're a certified prince.";
 
-    // Your private data and secret key
-    $plaintext = "You're a certified prince.";
-    $key = "1-2-3-4-5"; // same combination on my luggage
+// Generate once, store securely, and reuse for decryption.
+$key = sodium_bin2hex(
+    random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES)
+);
 
-    // Generate a secure random salt value
-    $salt = Cryptex::generateSalt();
+// Store this salt with the ciphertext; it is not embedded in the output.
+$salt = Cryptex::generateSalt();
+$ciphertext = Cryptex::encrypt($plaintext, $key, $salt);
+$decrypted = Cryptex::decrypt($ciphertext, $key, $salt);
 
-    // Encrypt the plaintext using the preserved v4-style API and hex ciphertext output
-    $ciphertext = Cryptex::encrypt($plaintext, $key, $salt);
-    // example result: 
-    // 4c406399a8830dbf670832b298980280d71bfb8cba53246ed45c9b6e6fc753bc100da3d10d4bf0d406d8afd18b8a5a79f44e50424ed0970914490706418c5725258e
-
-    // Decrypt the ciphertext with the same v4-style API
-    $result = Cryptex::decrypt($ciphertext, $key, $salt);
-
-} catch (Exception $e) {
-
-    // There was some error during salt generation, encryption, authentication, or decryption
-    echo 'Caught exception: ' . $e->getMessage() . "\n";
-
+if (!hash_equals($plaintext, $decrypted)) {
+    throw new RuntimeException('Round trip failed');
 }
-
-// Verify with a timing attack safe string comparison
-if (hash_equals($plaintext, $result)) {
-
-    // Cryptex securely encrypted and decrypted the data
-    echo "Pass";
-
-} else {
-
-    // There was some failure that did not generate any exceptions
-    echo "Fail";
-
-}
-
-// The above example will output: Pass
 ```
 
-## Release Notes
+Do not generate a new key or salt when decrypting stored ciphertext. Retrieve the exact values used during encryption.
 
-See [CHANGELOG.md](CHANGELOG.md) for the v5.0.0 release summary and compatibility notes.
+### Random keys and human passphrases
 
+Cryptex processes the supplied `$key` through Argon2id whether it contains random key material or a human passphrase. High-entropy random key material is preferred when the application can generate and store it safely.
 
-# Testing
+Argon2id makes passphrase guessing more expensive, but it does not add entropy or make a weak passphrase strong. Password policy, passphrase quality, key rotation, and secure key storage are caller responsibilities. This release deliberately does not reject previously accepted key strings.
 
-The PHPUnit test class is in `tests/CryptexTest.php`.
+### Salt handling
 
-If you installed Cryptex with Composer, you can run the following commands in the top-level folder of this project:
+`Cryptex::generateSalt()` returns `SODIUM_CRYPTO_PWHASH_SALTBYTES` random bytes. The salt is not a secret, but it must be stored without alteration and supplied again for decryption. A newly generated salt should normally be retained alongside each ciphertext.
 
-`composer test`
+### Ciphertext format and compatibility
 
-`composer lint`
+`encrypt()` returns lowercase hexadecimal encoding of:
 
-The PHPUnit command used by `composer test` is:
+```text
+24-byte nonce || ciphertext || 16-byte authentication tag
+```
 
-`./vendor/bin/phpunit --configuration phpunit.xml.dist`
+The salt is external and is not included in the ciphertext. The minimum decoded payload is 40 bytes (80 hexadecimal characters), representing an empty plaintext. v4 and v5 use this same unversioned format. Authentication failure, including a modified nonce, ciphertext, tag, wrong key, or wrong salt, throws `cryptex\DecryptionException` and never returns plaintext.
 
+A future major version may introduce a versioned envelope or additional authenticated data (AAD), but neither is part of the current API.
 
-# Generating Documentation
+### Strict scalar types
 
-Cryptex uses phpDocumentor to automatically generate documentation whenever changes are made. The generated documentation is [available online here](https://michaelmawhinney.github.io/cryptex/). However if you want to generate the documentation locally, you can run the following command in the top-level folder of this project (requires docker):
+PHP decides scalar argument coercion from the file that calls a function, not from the file that declares it. Cryptex declares strict types internally, but callers that require strict scalar enforcement should also begin their PHP files with:
 
-`docker run --rm -v "$(pwd):/data" "phpdoc/phpdoc:3" -d src,tests -t docs`
+```php
+declare(strict_types=1);
+```
 
-If you want to use another method of running/installing phpdoc, refer to the [phpDocumentor documentation](https://www.phpdoc.org/).
+### Untrusted input and payload limits
+
+Cryptex rejects invalid salt lengths, malformed hex, and decoded payloads that are too short before running Argon2id. It intentionally does not impose an arbitrary maximum ciphertext size because doing so would change the existing API.
+
+Applications accepting untrusted input should enforce suitable HTTP request, field, and ciphertext-size limits before calling `decrypt()`. Choose limits from the application's maximum expected plaintext size and resource budget so oversized input cannot consume unbounded decoding memory or request time.
+
+## Exceptions
+
+The public exception classes are PSR-4 autoloadable under the `cryptex\` namespace:
+
+- `EncryptionException`
+- `EncodingException`
+- `NonceLengthException`
+- `DecryptionException`
+- `SaltLengthException`
+
+Their names and existing inheritance hierarchy remain compatible with v4 and v5.
+
+## Development checks
+
+Run the following commands from the repository root:
+
+```console
+composer validate --strict
+composer audit --locked
+composer lint
+composer cs-check
+composer stan
+composer test
+```
+
+## Release notes
+
+See [CHANGELOG.md](CHANGELOG.md) and [RELEASE_NOTES.md](RELEASE_NOTES.md) for release and compatibility notes.
+
+## Generating documentation
+
+The API documentation is generated with phpDocumentor and published at <https://michaelmawhinney.github.io/cryptex/>. To generate it locally with Docker:
+
+```console
+docker run --rm -v "$(pwd):/data" phpdoc/phpdoc:3 -d src,tests -t docs
+```

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,14 @@
         }
     },
     "scripts": {
-        "test": "@php vendor/bin/phpunit --configuration phpunit.xml.dist",
-        "lint": "@php tools/lint.php"
+        "cs-check": "@php vendor/bin/phpcs --standard=phpcs.xml.dist -n",
+        "lint": "@php tools/lint.php",
+        "stan": "@php vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress",
+        "test": "@php vendor/bin/phpunit --configuration phpunit.xml.dist"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12"
+        "phpstan/phpstan": "^2.2",
+        "phpunit/phpunit": "^12",
+        "squizlabs/php_codesniffer": "^4.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "089f2d151b2ff91198d5f2a11d152204",
+    "content-hash": "e5ebb455a742cc15fcd6408f228d277e",
     "packages": [],
     "packages-dev": [
         {
@@ -242,6 +242,70 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1574,6 +1638,85 @@
                 }
             ],
             "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-10T16:43:36+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Cryptex">
+    <description>Coding standard for the Cryptex library.</description>
+
+    <file>src</file>
+    <file>tests</file>
+    <file>tools</file>
+
+    <arg name="basepath" value="."/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="8"/>
+
+    <rule ref="PSR12"/>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src

--- a/src/Cryptex.php
+++ b/src/Cryptex.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace cryptex;
 
+require_once __DIR__ . '/EncryptionException.php';
+require_once __DIR__ . '/EncodingException.php';
+require_once __DIR__ . '/NonceLengthException.php';
+require_once __DIR__ . '/DecryptionException.php';
+require_once __DIR__ . '/SaltLengthException.php';
+
 /**
  * Authenticated encryption with XChaCha20-Poly1305.
  *
@@ -25,7 +31,6 @@ final class Cryptex
      * @param string $key Passphrase or key material.
      * @param string $salt Salt of length SODIUM_CRYPTO_PWHASH_SALTBYTES.
      * @return string Hex-encoded nonce and ciphertext.
-     * @throws EncryptionException If encryption fails.
      * @throws SaltLengthException If the salt length is invalid.
      * @throws \Random\RandomException If nonce generation fails.
      * @throws \SodiumException If key derivation or encryption fails.
@@ -34,6 +39,7 @@ final class Cryptex
     {
         $derivedKey = '';
         try {
+            self::assertValidSaltLength($salt);
             $derivedKey = self::generateDerivedKey($key, $salt);
             $nonce = random_bytes(self::NONCE_LENGTH);
             $encryptedPayload = sodium_crypto_aead_xchacha20poly1305_ietf_encrypt(
@@ -42,10 +48,6 @@ final class Cryptex
                 $nonce,
                 $derivedKey
             );
-
-            if ($encryptedPayload === false) {
-                throw new EncryptionException('Failed to encrypt the data');
-            }
 
             return sodium_bin2hex($nonce . $encryptedPayload);
         } finally {
@@ -69,13 +71,14 @@ final class Cryptex
     {
         $derivedKey = '';
         try {
-            $derivedKey = self::generateDerivedKey($key, $salt);
+            self::assertValidSaltLength($salt);
             $decodedPayload = sodium_hex2bin($ciphertext);
 
             if (strlen($decodedPayload) < self::MINIMUM_DECODED_PAYLOAD_LENGTH) {
                 throw new NonceLengthException('Decoded data is shorter than the minimum payload length');
             }
 
+            $derivedKey = self::generateDerivedKey($key, $salt);
             $nonce = substr($decodedPayload, 0, self::NONCE_LENGTH);
             $encryptedPayload = substr($decodedPayload, self::NONCE_LENGTH);
 
@@ -113,13 +116,10 @@ final class Cryptex
      * @param string $key Passphrase or key material.
      * @param string $salt Salt value of length SODIUM_CRYPTO_PWHASH_SALTBYTES.
      * @return string Derived binary key.
-     * @throws SaltLengthException If the salt is not the expected length.
      * @throws \SodiumException If key derivation fails.
      */
     private static function generateDerivedKey(string $key, string $salt): string
     {
-        self::assertValidSaltLength($salt);
-
         return sodium_crypto_pwhash(
             \SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES,
             $key,
@@ -138,27 +138,12 @@ final class Cryptex
         }
     }
 
-    private static function wipeBuffer(string &$buffer): void
+    private static function wipeBuffer(?string &$buffer): void
     {
-        if ($buffer === '') {
+        if ($buffer === null || $buffer === '') {
             return;
         }
 
         sodium_memzero($buffer);
     }
 }
-
-/** Thrown when encryption fails. */
-class EncryptionException extends \Exception {}
-
-/** Thrown when encoding or decoding fails. */
-class EncodingException extends EncryptionException {}
-
-/** Thrown when the decoded payload is too short. */
-class NonceLengthException extends EncryptionException {}
-
-/** Thrown when authentication fails. */
-class DecryptionException extends EncryptionException {}
-
-/** Thrown when the supplied salt length is invalid. */
-class SaltLengthException extends EncryptionException {}

--- a/src/DecryptionException.php
+++ b/src/DecryptionException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/** Thrown when authentication fails. */
+class DecryptionException extends EncryptionException
+{
+}

--- a/src/EncodingException.php
+++ b/src/EncodingException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/** Thrown when encoding or decoding fails. */
+class EncodingException extends EncryptionException
+{
+}

--- a/src/EncryptionException.php
+++ b/src/EncryptionException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/** Thrown when encryption fails. */
+class EncryptionException extends \Exception
+{
+}

--- a/src/NonceLengthException.php
+++ b/src/NonceLengthException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/** Thrown when the decoded payload is too short. */
+class NonceLengthException extends EncryptionException
+{
+}

--- a/src/SaltLengthException.php
+++ b/src/SaltLengthException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/** Thrown when the supplied salt length is invalid. */
+class SaltLengthException extends EncryptionException
+{
+}

--- a/tests/CryptexTest.php
+++ b/tests/CryptexTest.php
@@ -20,7 +20,7 @@ final class CryptexTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->key = '1-2-3-4-5';
+        $this->key = 'test-only-key-material';
         $this->salt = Cryptex::generateSalt();
         $this->plaintext = "You're a certified prince.";
         $this->ciphertext = Cryptex::encrypt($this->plaintext, $this->key, $this->salt);
@@ -78,9 +78,31 @@ final class CryptexTest extends TestCase
         Cryptex::decrypt($this->ciphertext, $this->key, Cryptex::generateSalt());
     }
 
+    public function testDecryptRejectsTamperedNonce(): void
+    {
+        $tamperedCiphertext = $this->flipDecodedByte($this->ciphertext, 0);
+
+        $this->expectException(DecryptionException::class);
+
+        Cryptex::decrypt($tamperedCiphertext, $this->key, $this->salt);
+    }
+
     public function testDecryptRejectsTamperedCiphertext(): void
     {
-        $tamperedCiphertext = $this->flipLastHexNibble($this->ciphertext);
+        $tamperedCiphertext = $this->flipDecodedByte(
+            $this->ciphertext,
+            SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
+        );
+
+        $this->expectException(DecryptionException::class);
+
+        Cryptex::decrypt($tamperedCiphertext, $this->key, $this->salt);
+    }
+
+    public function testDecryptRejectsTamperedAuthenticationTag(): void
+    {
+        $decodedLength = strlen(sodium_hex2bin($this->ciphertext));
+        $tamperedCiphertext = $this->flipDecodedByte($this->ciphertext, $decodedLength - 1);
 
         $this->expectException(DecryptionException::class);
 
@@ -92,6 +114,20 @@ final class CryptexTest extends TestCase
         $this->expectException(SodiumException::class);
 
         Cryptex::decrypt('invalid ciphertext', $this->key, $this->salt);
+    }
+
+    public function testDecryptRejectsOddLengthHexCiphertext(): void
+    {
+        $this->expectException(SodiumException::class);
+
+        Cryptex::decrypt('abc', $this->key, $this->salt);
+    }
+
+    public function testDecryptValidatesSaltBeforeCiphertext(): void
+    {
+        $this->expectException(SaltLengthException::class);
+
+        Cryptex::decrypt('invalid ciphertext', $this->key, 'short');
     }
 
     public function testDecryptRejectsTooShortPayload(): void
@@ -152,8 +188,21 @@ final class CryptexTest extends TestCase
         $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $this->key, $this->salt));
     }
 
+    public function testDecryptsFixedLegacyV4Ciphertext(): void
+    {
+        // Pre-generated v4-format fixture; this test must not call encrypt().
+        $salt = sodium_hex2bin('000102030405060708090a0b0c0d0e0f');
+        $key = 'legacy-v4-fixture-passphrase';
+        $ciphertext = '101112131415161718191a1b1c1d1e1f2021222324252627'
+            . '10c5138293480a1f0baff8559cc7df6ae15d86183676a72a83b7da8b996f66c04aa46fa59961d597b117f41b0ab6d008';
+
+        $plaintext = Cryptex::decrypt($ciphertext, $key, $salt);
+
+        $this->assertSame('Cryptex v4 compatibility fixture', $plaintext);
+    }
+
     #[DataProvider('invalidPlaintextProvider')]
-    public function testEncryptRejectsInvalidPlaintextTypes($plaintext): void
+    public function testEncryptRejectsInvalidPlaintextTypes(mixed $plaintext): void
     {
         $this->expectException(\TypeError::class);
 
@@ -161,7 +210,7 @@ final class CryptexTest extends TestCase
     }
 
     #[DataProvider('invalidCiphertextProvider')]
-    public function testDecryptRejectsInvalidCiphertextTypes($ciphertext): void
+    public function testDecryptRejectsInvalidCiphertextTypes(mixed $ciphertext): void
     {
         $this->expectException(\TypeError::class);
 
@@ -169,7 +218,7 @@ final class CryptexTest extends TestCase
     }
 
     #[DataProvider('invalidKeyProvider')]
-    public function testEncryptRejectsInvalidKeyTypes($key): void
+    public function testEncryptRejectsInvalidKeyTypes(mixed $key): void
     {
         $this->expectException(\TypeError::class);
 
@@ -177,7 +226,7 @@ final class CryptexTest extends TestCase
     }
 
     #[DataProvider('invalidKeyProvider')]
-    public function testDecryptRejectsInvalidKeyTypes($key): void
+    public function testDecryptRejectsInvalidKeyTypes(mixed $key): void
     {
         $this->expectException(\TypeError::class);
 
@@ -185,7 +234,7 @@ final class CryptexTest extends TestCase
     }
 
     #[DataProvider('invalidSaltTypeProvider')]
-    public function testEncryptRejectsInvalidSaltTypes($salt): void
+    public function testEncryptRejectsInvalidSaltTypes(mixed $salt): void
     {
         $this->expectException(\TypeError::class);
 
@@ -193,13 +242,14 @@ final class CryptexTest extends TestCase
     }
 
     #[DataProvider('invalidSaltTypeProvider')]
-    public function testDecryptRejectsInvalidSaltTypes($salt): void
+    public function testDecryptRejectsInvalidSaltTypes(mixed $salt): void
     {
         $this->expectException(\TypeError::class);
 
         Cryptex::decrypt($this->ciphertext, $this->key, $salt);
     }
 
+    /** @return array<string, array{mixed}> */
     public static function invalidPlaintextProvider(): array
     {
         return [
@@ -209,6 +259,7 @@ final class CryptexTest extends TestCase
         ];
     }
 
+    /** @return array<string, array{mixed}> */
     public static function invalidCiphertextProvider(): array
     {
         return [
@@ -218,6 +269,7 @@ final class CryptexTest extends TestCase
         ];
     }
 
+    /** @return array<string, array{mixed}> */
     public static function invalidKeyProvider(): array
     {
         return [
@@ -227,6 +279,7 @@ final class CryptexTest extends TestCase
         ];
     }
 
+    /** @return array<string, array{mixed}> */
     public static function invalidSaltTypeProvider(): array
     {
         return [
@@ -236,6 +289,7 @@ final class CryptexTest extends TestCase
         ];
     }
 
+    /** @return array<string, array{string}> */
     public static function invalidSaltLengthProvider(): array
     {
         return [
@@ -245,11 +299,11 @@ final class CryptexTest extends TestCase
         ];
     }
 
-    private function flipLastHexNibble(string $hex): string
+    private function flipDecodedByte(string $hex, int $offset): string
     {
-        $lastNibble = substr($hex, -1);
-        $replacement = $lastNibble === '0' ? '1' : '0';
+        $decoded = sodium_hex2bin($hex);
+        $decoded[$offset] = chr(ord($decoded[$offset]) ^ 1);
 
-        return substr($hex, 0, -1) . $replacement;
+        return sodium_bin2hex($decoded);
     }
 }

--- a/tests/DecryptValidationOrderTest.php
+++ b/tests/DecryptValidationOrderTest.php
@@ -28,4 +28,17 @@ final class DecryptValidationOrderTest extends TestCase
 
         Cryptex::decrypt(sodium_bin2hex($payload), 'test-only-key-material', $salt);
     }
+
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testMalformedHexIsRejectedBeforeKeyDerivation(): void
+    {
+        require __DIR__ . '/Fixtures/KdfGuard.php';
+
+        $salt = str_repeat("\x00", SODIUM_CRYPTO_PWHASH_SALTBYTES);
+
+        $this->expectException(\SodiumException::class);
+
+        Cryptex::decrypt('zz', 'test-only-key-material', $salt);
+    }
 }

--- a/tests/DecryptValidationOrderTest.php
+++ b/tests/DecryptValidationOrderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class DecryptValidationOrderTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testTooShortPayloadIsRejectedBeforeKeyDerivation(): void
+    {
+        require __DIR__ . '/Fixtures/KdfGuard.php';
+
+        $payload = str_repeat(
+            "\x00",
+            SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES
+                + SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_ABYTES
+                - 1
+        );
+        $salt = str_repeat("\x00", SODIUM_CRYPTO_PWHASH_SALTBYTES);
+
+        $this->expectException(NonceLengthException::class);
+
+        Cryptex::decrypt(sodium_bin2hex($payload), 'test-only-key-material', $salt);
+    }
+}

--- a/tests/DirectIncludeCompatibilityTest.php
+++ b/tests/DirectIncludeCompatibilityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+final class DirectIncludeCompatibilityTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testDirectIncludeSupportsEncryptDecryptRoundTrip(): void
+    {
+        $composerLoaderReplaced = false;
+
+        foreach (spl_autoload_functions() as $autoload) {
+            if (is_array($autoload) && $autoload[0] instanceof ClassLoader) {
+                spl_autoload_unregister($autoload);
+                spl_autoload_register(
+                    static function (string $class) use ($autoload): void {
+                        if (str_starts_with($class, __NAMESPACE__ . '\\')) {
+                            return;
+                        }
+
+                        $autoload[0]->loadClass($class);
+                    }
+                );
+                $composerLoaderReplaced = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($composerLoaderReplaced);
+        $this->assertFalse(class_exists(Cryptex::class));
+
+        require __DIR__ . '/../src/Cryptex.php';
+
+        $salt = str_repeat("\x00", SODIUM_CRYPTO_PWHASH_SALTBYTES);
+        $plaintext = 'direct include compatibility';
+        $key = 'test-only-key-material';
+        $ciphertext = Cryptex::encrypt($plaintext, $key, $salt);
+
+        $this->assertSame($plaintext, Cryptex::decrypt($ciphertext, $key, $salt));
+    }
+}

--- a/tests/ExceptionAutoloadTest.php
+++ b/tests/ExceptionAutoloadTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class ExceptionAutoloadTest extends TestCase
+{
+    #[DataProvider('publicExceptionProvider')]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testPublicExceptionCanBeAutoloadedIndependently(string $className, string $parentClass): void
+    {
+        $this->assertFalse(class_exists(Cryptex::class, false));
+        $this->assertFalse(class_exists($className, false));
+        $this->assertTrue(class_exists($className));
+        $this->assertTrue(is_subclass_of($className, $parentClass));
+        $this->assertFalse(class_exists(Cryptex::class, false));
+
+        $reflection = new ReflectionClass($className);
+        $fileName = $reflection->getFileName();
+
+        $this->assertIsString($fileName);
+        $this->assertSame($reflection->getShortName() . '.php', basename($fileName));
+    }
+
+    /** @return array<string, array{class-string<\Throwable>, class-string<\Throwable>}> */
+    public static function publicExceptionProvider(): array
+    {
+        return [
+            'encryption' => [EncryptionException::class, \Exception::class],
+            'encoding' => [EncodingException::class, EncryptionException::class],
+            'nonce length' => [NonceLengthException::class, EncryptionException::class],
+            'decryption' => [DecryptionException::class, EncryptionException::class],
+            'salt length' => [SaltLengthException::class, EncryptionException::class],
+        ];
+    }
+}

--- a/tests/Fixtures/KdfGuard.php
+++ b/tests/Fixtures/KdfGuard.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace cryptex;
+
+/**
+ * Test-only namespace override that fails if invalid ciphertext reaches Argon2id.
+ */
+function sodium_crypto_pwhash(
+    int $length,
+    string $password,
+    string $salt,
+    int $opslimit,
+    int $memlimit,
+    int $algo
+): string {
+    throw new \LogicException('Key derivation ran before ciphertext validation');
+}


### PR DESCRIPTION
## Summary

This PR performs a focused security and quality hardening pass while preserving Cryptex’s existing public API and ciphertext compatibility.

### Changes

* Rejects invalid salt lengths, malformed hexadecimal ciphertext, and undersized decoded payloads before running Argon2id.
* Adds regression coverage proving malformed input is rejected before key derivation.
* Adds explicit tests for tampered nonces, ciphertext, and authentication tags.
* Adds a fixed v4-format ciphertext compatibility fixture.
* Moves public exception classes into independently PSR-4-autoloadable files.
* Preserves direct `src/Cryptex.php` inclusion without Composer autoloading.
* Adds PHPStan and PHP_CodeSniffer as development-only tooling.
* Adds dependency auditing, static analysis, and coding-style checks to CI.
* Applies least-privilege GitHub Actions permissions and pins verified actions to immutable commit SHAs.
* Removes the documentation branch force-push and deploys GitHub Pages through an artifact.
* Improves documentation for random keys, passphrases, Argon2id, external salts, strict scalar typing, ciphertext structure, and application-level payload limits.

## Security rationale

Previously, `decrypt()` derived the key with Argon2id before validating whether the ciphertext was valid hexadecimal or structurally long enough. Invalid attacker-controlled input could therefore trigger unnecessary CPU and memory-intensive key derivation.

The new validation order is:

1. validate salt length;
2. decode hexadecimal ciphertext;
3. validate minimum decoded payload length;
4. derive the key;
5. authenticate and decrypt.

Authentication behavior remains fail-closed, and no unauthenticated plaintext is returned.

## Compatibility

This PR preserves:

* `Cryptex::encrypt()`, `Cryptex::decrypt()`, and `Cryptex::generateSalt()`;
* existing namespaces and public exception class names;
* the existing exception inheritance hierarchy and observable exception behavior;
* Argon2id parameters;
* external salt handling;
* the v4/v5 hexadecimal ciphertext format;
* decryption of the fixed v4-format compatibility fixture;
* direct inclusion of `src/Cryptex.php`.

No versioned envelope, embedded salt, AAD support, new public API, key-policy enforcement, or ciphertext-size limit is introduced.

## Validation

The following checks pass:

* `composer validate --strict`
* `composer audit --locked`
* `composer lint`
* `composer cs-check`
* `composer stan`
* `composer test` — 51 tests, 84 assertions
* `git diff --check`

## Deferred work

A versioned ciphertext envelope, embedded salt support, and authenticated additional data remain appropriate candidates for a future major release.

The `phpdoc/phpdoc:3` Docker image remains referenced by tag because an immutable digest could not be independently verified with the available tooling.